### PR TITLE
Update thailand.json

### DIFF
--- a/src/data/countries/thailand.json
+++ b/src/data/countries/thailand.json
@@ -78,16 +78,16 @@
         },
         "frequency": {
           "arfcn": {
-            "LTE":[9460,9485,9510,9535],
-            "NR":[156030,156050]
+            "LTE":[9460,9485,9510,9535,9558],
+            "NR":[156030,156050,156250]
           },
           "downLink": {
             "start": 778,
-            "end": 793
+            "end": 798
           },
           "upLink": {
             "start": 723,
-            "end": 738
+            "end": 743
           }
         },
         "technology": [
@@ -96,12 +96,20 @@
         ],
         "source": [
           {
+            "name": "AIS - NT and AIS join forces to increase 4G/5G capability on the 700 MHz spectrum",
+            "url": "https://www.ais.th/en/business/news-and-activity/announcements/nt-and-ais-join-forces-to-increase-4g-5g-capability-on-the-700-mhz-spectrum"
+          },
+          {
             "name": "AIS Newsroom",
             "url": "https://investor-th.ais.co.th/news.html/id/815342/group/newsroom_press"
           },
           {
             "name": "Droidsans - สรุปประมูล 5G สร้างรายได้กว่าแสนล้าน",
             "url": "https://droidsans.com/5g-auction-final-report/"
+          },
+          {
+            "name": "LightReading - AIS bolsters 5G credentials with purchase of 700MHz spectrum license from NT",
+            "url": "https://www.lightreading.com/5g/ais-bolsters-5g-posture-amid-purchase-of-700mhz-spectrum-license-from-nt"
           }
         ]
       },
@@ -110,26 +118,38 @@
           "name": "NT",
           "longName": "National Telecom",
           "homePage": "https://www.ntplc.co.th/",
-          "backgroundColor": "#312783",
-          "textColor": "white"
+          "backgroundColor": "#ffe000",
+          "textColor": "#52595f"
         },
         "frequency": {
           "downLink": {
-            "start": 793,
+            "start": 798,
             "end": 803
           },
           "upLink": {
-            "start": 738,
+            "start": 743,
             "end": 748
+          },
+          "arfcn": {
+            "LTE":[9635]
           }
         },
         "technology": [
+          "LTE",
           "NR"
         ],
         "source": [
           {
+            "name": "AIS - NT and AIS join forces to increase 4G/5G capability on the 700 MHz spectrum",
+            "url": "https://www.ais.th/en/business/news-and-activity/announcements/nt-and-ais-join-forces-to-increase-4g-5g-capability-on-the-700-mhz-spectrum"
+          },
+          {
             "name": "Droidsans - สรุปประมูล 5G สร้างรายได้กว่าแสนล้าน",
             "url": "https://droidsans.com/5g-auction-final-report/"
+          },
+          {
+            "name": "LightReading - AIS bolsters 5G credentials with purchase of 700MHz spectrum license from NT",
+            "url": "https://www.lightreading.com/5g/ais-bolsters-5g-posture-amid-purchase-of-700mhz-spectrum-license-from-nt"
           }
         ]
       }
@@ -183,8 +203,8 @@
           "name": "NT",
           "longName": "National Telecom",
           "homePage": "https://www.ntplc.co.th/",
-          "backgroundColor": "#312783",
-          "textColor": "white"
+          "backgroundColor": "#ffe000",
+          "textColor": "#52595f"
         },
         "frequency": {
           "arfcn": {
@@ -527,8 +547,8 @@
           "name": "NT",
           "longName": "National Telecom",
           "homePage": "https://www.ntplc.co.th/",
-          "backgroundColor": "#312783",
-          "textColor": "white"
+          "backgroundColor": "#ffe000",
+          "textColor": "#52595f"
         },
         "frequency": {
           "arfcn": {
@@ -565,8 +585,8 @@
           "name": "NT",
           "longName": "National Telecom",
           "homePage": "https://www.ntplc.co.th/",
-          "backgroundColor": "#312783",
-          "textColor": "white"
+          "backgroundColor": "#ffe000",
+          "textColor": "#52595f"
         },
         "frequency": {
           "arfcn": {
@@ -728,8 +748,8 @@
           "name": "NT",
           "longName": "National Telecom",
           "homePage": "https://www.ntplc.co.th/",
-          "backgroundColor": "#312783",
-          "textColor": "white"
+          "backgroundColor": "#ffe000",
+          "textColor": "#52595f"
         },
         "frequency": {
           "downLink": {


### PR DESCRIPTION
I've updated the current allocations for Thailand, especially 700 MHz (Band 28), and NT (National Telecom)'s current brand colors.

NT's current brand colors are derived from http://101.109.250.52/logo.html .

Additionally, CellMapper links from [AIS](https://www.cellmapper.net/map?MCC=520&MNC=3&type=LTE&latitude=14.041223795257977&longitude=100.60620789124026&zoom=15.650667419433441&showTowers=true&showIcons=true&showTowerLabels=true&clusterEnabled=true&tilesEnabled=true&showOrphans=false&showNoFrequencyOnly=false&showFrequencyOnly=true&showBandwidthOnly=false&DateFilterType=Last&showHex=false&bands=28&showVerifiedOnly=false&showUnverifiedOnly=false&showLTECAOnly=false&showENDCOnly=false&showBand=28&showSectorColours=true&mapType=roadmap&darkMode=false&imperialUnits=false) and [NT](https://www.cellmapper.net/map?MCC=520&MNC=2&type=LTE&latitude=13.880653924356238&longitude=100.5697526513838&zoom=13.549000752766776&showTowers=true&showIcons=true&showTowerLabels=true&clusterEnabled=true&tilesEnabled=true&showOrphans=false&showNoFrequencyOnly=false&showFrequencyOnly=false&showBandwidthOnly=false&DateFilterType=Last&showHex=false&showVerifiedOnly=false&showUnverifiedOnly=false&showLTECAOnly=false&showENDCOnly=false&showBand=0&showSectorColours=true&mapType=roadmap&darkMode=false&imperialUnits=false) for 700 MHz (Band 28) may be used to verify the EARFCN values and frequencies in use.